### PR TITLE
Add support for commit statuses

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** -diff linguist-generated=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         name: Approve BackstopJS
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          type: check
           check_name: BackstopJS visual test
           approve_comment: backstop-check approve
 
@@ -35,5 +36,6 @@ jobs:
         name: Approve Cypress
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          type: check
           check_name: Cypress
           approve_comment: cypress-check approve

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,12 @@ description: "Approve any check no matter it's actual conclusion."
 inputs:
   github_token:
     required: true
-  check_name:
+  type:
     required: true
-    default: "BackstopJS visual test"
+    default: "status"
+  name:
+    required: true
+    default: "Visual regression test"
   approve_comment:
     required: true
     default: "backstop-check approve"


### PR DESCRIPTION
Turns out there are checks and commit statuses.

The one we want to change when using BackstopJS is a commit status and this tools supports checks...

Let's support both. With statuses being the default since that is our main use case.

Example of use, see: https://github.com/arnested/playground/pull/38

Before comment:

![image](https://user-images.githubusercontent.com/190005/146972328-5c6d6996-c94a-4a5d-b3b8-715dbba2fb78.png)

After comment:

![image](https://user-images.githubusercontent.com/190005/146972457-8f50fce1-72b9-4c5f-833b-c2ecee47bac9.png)
