### PR TITLE
Allow the accept command to be a substring of the comment

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8320,7 +8320,7 @@ function run() {
             const name = core.getInput("name");
             const approveCommand = core.getInput("approve_comment");
             const type = core.getInput("type");
-            const shouldRun = (comment === null || comment === void 0 ? void 0 : comment.body) === approveCommand;
+            const shouldRun = comment === null || comment === void 0 ? void 0 : comment.body.includes(approveCommand);
             if (!shouldRun)
                 return;
             const octokit = github.getOctokit(token);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ async function run() {
     const approveCommand = core.getInput("approve_comment");
     const type = core.getInput("type");
 
-    const shouldRun = comment?.body === approveCommand;
+    const shouldRun = comment?.body.includes(approveCommand);
     if (!shouldRun) return;
 
     const octokit = github.getOctokit(token);


### PR DESCRIPTION
Until now the comment could only contain the accept command. Now it is
fine if the accept command just is present somewhere in the command.

The use case is being able to write the command _and_ a prose
description of why you have decided to accept the result.
